### PR TITLE
Agrega un método de login a servidor JWT scheduled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <joko-security.version>1.1.1</joko-security.version>
+        <joko-security.version>1.1.2</joko-security.version>
         <joko-utils.version>0.6.1</joko-utils.version>
         <commons-lang3.version>3.1</commons-lang3.version>
         <commons-collections4.version>4.1</commons-collections4.version>
@@ -238,6 +238,12 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <!-- https://mvnrepository.com/artifact/org.sonarsource.scanner.maven/sonar-maven-plugin -->
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>3.6.1.1688</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/io/github/jokoframework/wilson/auth/AuthorizationManagerImpl.java
+++ b/src/main/java/io/github/jokoframework/wilson/auth/AuthorizationManagerImpl.java
@@ -47,6 +47,7 @@ public class AuthorizationManagerImpl implements JokoAuthorizationManager {
                 .antMatchers("/h2-console/**").permitAll()
                 .antMatchers("/**/heartbeat").permitAll()
                 .antMatchers(ApiPaths.COUNTRIES).permitAll()
+                .antMatchers(ApiPaths.TEST_GET_STORED_SECRET).permitAll()
                 .antMatchers(ApiPaths.API_SESSIONS).hasAnyAuthority(ADMIN.name())
                 // Users
                 .antMatchers(ApiPaths.ROOT_USERS,

--- a/src/main/java/io/github/jokoframework/wilson/constants/ApiPaths.java
+++ b/src/main/java/io/github/jokoframework/wilson/constants/ApiPaths.java
@@ -45,9 +45,13 @@ public class ApiPaths {
     public static final String PERSON_BY_NAME = ROOT_PERSON + "/{name}";
 
     public static final String PERSON_CSV = ROOT_PERSON + "/csv";
-    
+
+    /**
+     * route for scheduler management
+     */
+    public static final String TEST_GET_STORED_SECRET = BASE + "/test/get/secret";
+
     private ApiPaths() {
         
     }
-
 }

--- a/src/main/java/io/github/jokoframework/wilson/scheduler/ScheduledTasks.java
+++ b/src/main/java/io/github/jokoframework/wilson/scheduler/ScheduledTasks.java
@@ -1,0 +1,72 @@
+package io.github.jokoframework.wilson.scheduler;
+
+import java.text.SimpleDateFormat;
+
+import io.github.jokoframework.wilson.scheduler.dto.LoginRequestDTO;
+import io.github.jokoframework.wilson.scheduler.dto.LoginResponseDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class ScheduledTasks {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScheduledTasks.class);
+    private final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
+
+    @Value("${scheduler.login.url}")
+    private String loginUrl;
+    @Value("${scheduler.login.username}")
+    private String loginUsername;
+    @Value("${scheduler.login.password}")
+    private String loginPassword;
+
+    private static String secret;
+
+    @Scheduled(cron = "${scheduler.login.cron.timer}")
+    public void refreshLogin() {
+        // We build the request we want to send
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        LoginRequestDTO credentials = new LoginRequestDTO();
+        credentials.setUsername(loginUsername);
+        credentials.setPassword(loginPassword);
+
+
+        HttpEntity<LoginRequestDTO> request = new HttpEntity<>(credentials, headers);
+
+        // We make the request, logging response data and managing some types of exceptions
+        RestTemplate restTemplate = new RestTemplate();
+        try {
+            ResponseEntity<LoginResponseDTO> response = restTemplate.exchange(loginUrl,
+                    HttpMethod.POST,
+                    request,
+                    LoginResponseDTO.class);
+
+            // Secret is updated
+            if (response.getBody().getSecret() != null) {
+                setSecret(response.getBody().getSecret());
+                String expiration = dateFormat.format(response.getBody().getExpiration());
+                LOGGER.info("LOGIN SERVICE WAS REACHED - REFRESHED SECRET - EXPIRES ON = {}", expiration);
+            } else {
+                LOGGER.info("LOGIN SERVICE WAS REACHED - SECRET WAS NOT RETURNED BY SERVICE?");
+            }
+        } catch (ResourceAccessException e) {
+            LOGGER.info("LOGIN SERVICE COULD NOT BE REACHED");
+        }
+    }
+
+    public static void setSecret(String secret) {
+        ScheduledTasks.secret = secret;
+    }
+
+    public static String getSecret() {
+        return secret;
+    }
+}

--- a/src/main/java/io/github/jokoframework/wilson/scheduler/dto/LoginRequestDTO.java
+++ b/src/main/java/io/github/jokoframework/wilson/scheduler/dto/LoginRequestDTO.java
@@ -1,0 +1,32 @@
+package io.github.jokoframework.wilson.scheduler.dto;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public class LoginRequestDTO {
+    private String username;
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("username", username)
+                .append("password", password)
+                .toString();
+    }
+}

--- a/src/main/java/io/github/jokoframework/wilson/scheduler/dto/LoginResponseDTO.java
+++ b/src/main/java/io/github/jokoframework/wilson/scheduler/dto/LoginResponseDTO.java
@@ -1,0 +1,65 @@
+package io.github.jokoframework.wilson.scheduler.dto;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import java.util.Date;
+
+public class LoginResponseDTO {
+    private String success;
+    private String errorCode;
+    private String message;
+    private String secret;
+    private Date expiration;
+
+    public String getSuccess() {
+        return success;
+    }
+
+    public void setSuccess(String success) {
+        this.success = success;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(String errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public Date getExpiration() {
+        return expiration;
+    }
+
+    public void setExpiration(Date expiration) {
+        this.expiration = expiration;
+    }
+
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("success", success)
+                .append("errorCode", errorCode)
+                .append("message", message)
+                .append("secret", secret)
+                .append("expiration", expiration)
+                .toString();
+    }
+}

--- a/src/main/java/io/github/jokoframework/wilson/web/controller/BaseRestController.java
+++ b/src/main/java/io/github/jokoframework/wilson/web/controller/BaseRestController.java
@@ -1,6 +1,7 @@
 package io.github.jokoframework.wilson.web.controller;
 
 import io.github.jokoframework.wilson.constants.ApiPaths;
+import io.github.jokoframework.wilson.scheduler.ScheduledTasks;
 import io.github.jokoframework.wilson.web.response.HeartBeatResponseDTO;
 import io.github.jokoframework.wilson.web.session.SessionManager;
 import io.github.jokoframework.wilson.web.session.UserCurrentInfo;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
@@ -30,6 +32,11 @@ public abstract class BaseRestController {
     public ResponseEntity<HeartBeatResponseDTO> getHearbeat() {
         HeartBeatResponseDTO heartBeatResponseDTO = getHeartBeatStatus();
         return new ResponseEntity<>(heartBeatResponseDTO, heartBeatResponseDTO.getHttpStatus());
+    }
+
+    @GetMapping(value = ApiPaths.TEST_GET_STORED_SECRET)
+    public String getStoredSecret() {
+        return ScheduledTasks.getSecret();
     }
 
     public HeartBeatResponseDTO getHeartBeatStatus() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -56,3 +56,10 @@ spring.datasource.remove-abandoned-timeout=60
 #Spring Boot Actuator
 management.contextPath:/
 management.security.roles=END_USER, ADMIN
+
+# Data used by the scheduler Worker to Login to a JWT secured server
+# Cron String to define how often is the Login service reached
+scheduler.login.cron.timer=*/5 * * * * *
+scheduler.login.url=http://localhost:8085/api/login
+scheduler.login.username=admin
+scheduler.login.password=123456

--- a/src/main/resources/application.properties.example
+++ b/src/main/resources/application.properties.example
@@ -13,3 +13,10 @@ spring.datasource.password=postgres
 # Requisitos para Java 11 y Spring Boot 2
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
+
+# Data used by the scheduler Worker to Login to a JWT secured server
+# Cron String to define how often is the Login service reached
+scheduler.login.cron.timer=*/5 * * * * *
+scheduler.login.url=http://localhost:8085/api/login
+scheduler.login.username=admin
+scheduler.login.password=123456


### PR DESCRIPTION
Agrega método de login a servidor JWT que se corre cada cierta cantidad de tiempo, utilizando un URL de Login junto a un Usuario y Contreseña

Los 4 parametros mencionados se deben definir en el application.properties, se deja un ejemplo que detalla el nombre de los campos y valores utilizados para conectar a una instancia del Joko Backend Starter Kit (Con un puerto distinto al 8080).
```
scheduler.login.cron.timer=*/5 * * * * *
scheduler.login.url=http://localhost:8085/api/login
scheduler.login.username=admin
scheduler.login.password=123456
```

El timer seria un String de tiempo definido como en el crontab: https://crontab.guru/