### PR TITLE
Agrega endpoint maestro para Requests de tipo GET para utilizar el Cache de Wilson

### DIFF
--- a/RUN.md
+++ b/RUN.md
@@ -8,6 +8,7 @@ https://github.com/jokoframework/joko_backend_starter_kit
 * Maven
 * Java 11 (JDK11)
 * Base de datos PostgreSQL con el nombre *wilson*
+* Base de datos MongoDB
 
 
 ## Clonar proyecto
@@ -111,6 +112,13 @@ Entrar en el directorio de jada proyecto y hacer lo siguiente:
     $ ./scripts/updater update
   ```
     
+# Step 6) Preparar base de datos MongoDB.
+Para guardar los datos sobre que servicios se desea que Wilson aplique sus funcionalidades de Cache y para guardar el cache mismo se utiliza
+una base de datos MongoDB, la configuración de los parametros de conexión a esta base de datos se deben configurar en el application.properties
+
+En el archivo de ejemplo para el application.properties que se encuentra en `src/main/resources/application.properties.examples` se detallan
+campos para definir el HOST, PORT y NAME de la base de datos de MongoDB a la que se conectara Wilson
+
 ## Correr desde una consola con `mvn` (Maven)
 
 Si es una consola nueva exportar las variables primero:
@@ -144,4 +152,3 @@ Esta guía es especifica para estos dos programas pero la mayoría de los IDEs s
 El proyecto cuenta con documentación del API accesible desde el swagger-ui. URI al swagger:
 
 http://localhost:8080/swagger/index.html
-

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-mongodb</artifactId>
+            <version>2.1.10.RELEASE</version>
+        </dependency>
+
         <!--
         Joko dependencies
         -->

--- a/src/main/java/io/github/jokoframework/wilson/auth/AuthorizationManagerImpl.java
+++ b/src/main/java/io/github/jokoframework/wilson/auth/AuthorizationManagerImpl.java
@@ -53,7 +53,12 @@ public class AuthorizationManagerImpl implements JokoAuthorizationManager {
                 .antMatchers(ApiPaths.ROOT_USERS,
                         ApiPaths.USERS_HEARTBEAT,
                         ApiPaths.USERS_BY_NAME,
-                        ApiPaths.USERS_CSV).hasAnyAuthority(ADMIN.name());
+                        ApiPaths.USERS_CSV).hasAnyAuthority(ADMIN.name())
+                // Wilson
+                .antMatchers(ApiPaths.WILSON_MASTER,
+                        ApiPaths.WILSON_INSERT_READ_OPERATION,
+                        ApiPaths.WILSON_LIST_READ_OPERATION,
+                        ApiPaths.WILSON_UPDATE_READ_OPERATION_CACHE).permitAll();
 
         // Only in dev profile,
         // Allows X-Frame-Options headers sent by H2 console.

--- a/src/main/java/io/github/jokoframework/wilson/cache/entities/ReadCacheEntity.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/entities/ReadCacheEntity.java
@@ -1,0 +1,59 @@
+package io.github.jokoframework.wilson.cache.entities;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+public class ReadCacheEntity implements Serializable {
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime timeOfArrival;
+    private HttpHeaders headers;
+    private String body;
+    private HttpStatus statusCode;
+
+    public LocalDateTime getTimeOfArrival() {
+        return timeOfArrival;
+    }
+
+    public void setTimeOfArrival(LocalDateTime timeOfArrival) {
+        this.timeOfArrival = timeOfArrival;
+    }
+
+    public HttpHeaders getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(HttpHeaders headers) {
+        this.headers = headers;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public HttpStatus getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(HttpStatus statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("timeOfArrival", timeOfArrival)
+                .append("headers", headers)
+                .append("body", body)
+                .append("statusCode", statusCode)
+                .toString();
+    }
+}

--- a/src/main/java/io/github/jokoframework/wilson/cache/entities/ReadOperationEntity.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/entities/ReadOperationEntity.java
@@ -1,0 +1,72 @@
+package io.github.jokoframework.wilson.cache.entities;
+
+import io.github.jokoframework.wilson.cache.enums.ReadOperationHttpVerbEnum;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import javax.persistence.Id;
+import java.io.Serializable;
+
+@Document("readOperation")
+public class ReadOperationEntity implements Serializable {
+    @Id
+    @Field("_id")
+    private String uri;
+    private ReadOperationHttpVerbEnum requestType;
+    private Integer retryTimer;
+    private Integer maxAge;
+    private ReadCacheEntity responseCache;
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public ReadOperationHttpVerbEnum getRequestType() {
+        return requestType;
+    }
+
+    public void setRequestType(ReadOperationHttpVerbEnum requestType) {
+        this.requestType = requestType;
+    }
+
+    public Integer getRetryTimer() {
+        return retryTimer;
+    }
+
+    public void setRetryTimer(Integer retryTimer) {
+        this.retryTimer = retryTimer;
+    }
+
+    public Integer getMaxAge() {
+        return maxAge;
+    }
+
+    public void setMaxAge(Integer maxAge) {
+        this.maxAge = maxAge;
+    }
+
+    public ReadCacheEntity getResponseCache() {
+        return responseCache;
+    }
+
+    public void setResponseCache(ReadCacheEntity responseCache) {
+        this.responseCache = responseCache;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .appendSuper(super.toString())
+                .append("uri", uri)
+                .append("requestType", requestType)
+                .append("retryTimer", retryTimer)
+                .append("maxAge", maxAge)
+                .append("responseCache", responseCache)
+                .toString();
+    }
+}

--- a/src/main/java/io/github/jokoframework/wilson/cache/enums/ReadOperationHttpVerbEnum.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/enums/ReadOperationHttpVerbEnum.java
@@ -1,0 +1,5 @@
+package io.github.jokoframework.wilson.cache.enums;
+
+public enum ReadOperationHttpVerbEnum {
+    GET
+}

--- a/src/main/java/io/github/jokoframework/wilson/cache/repositories/ReadOperationRepository.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/repositories/ReadOperationRepository.java
@@ -1,0 +1,17 @@
+package io.github.jokoframework.wilson.cache.repositories;
+
+import io.github.jokoframework.wilson.cache.entities.ReadOperationEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReadOperationRepository extends MongoRepository<ReadOperationEntity, String> {
+
+    public ReadOperationEntity insert(ReadOperationEntity readOperationEntity);
+
+    public List<ReadOperationEntity> findAll();
+
+    public Optional<ReadOperationEntity> findByUri(String uri);
+
+}

--- a/src/main/java/io/github/jokoframework/wilson/cache/service/ReadOperationService.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/service/ReadOperationService.java
@@ -1,0 +1,22 @@
+package io.github.jokoframework.wilson.cache.service;
+
+import io.github.jokoframework.wilson.cache.entities.ReadCacheEntity;
+import io.github.jokoframework.wilson.cache.entities.ReadOperationEntity;
+import io.github.jokoframework.wilson.exceptions.ReadOperationException;
+
+import java.util.List;
+
+public interface ReadOperationService {
+
+    // ReadOperation services
+    public void insertReadOperation(ReadOperationEntity readOperationEntity);
+
+    public List<ReadOperationEntity> listReadOperations();
+
+    // Insert Test Data for a GET request
+    public void updateReadOperationCache(String service) throws ReadOperationException;
+
+    // ReadCache services
+    public void saveReadCache(String uri, ReadCacheEntity newCache);
+
+}

--- a/src/main/java/io/github/jokoframework/wilson/cache/service/WilsonMasterService.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/service/WilsonMasterService.java
@@ -1,0 +1,10 @@
+package io.github.jokoframework.wilson.cache.service;
+
+import org.springframework.http.ResponseEntity;
+
+public interface WilsonMasterService {
+
+    // Process GET requests from the Frontend, applying Cache functions if available
+    public ResponseEntity<Object> processGetRequest(String service);
+
+}

--- a/src/main/java/io/github/jokoframework/wilson/cache/service/impl/ReadOperationServiceImpl.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/service/impl/ReadOperationServiceImpl.java
@@ -1,0 +1,85 @@
+package io.github.jokoframework.wilson.cache.service.impl;
+
+import io.github.jokoframework.wilson.cache.entities.ReadCacheEntity;
+import io.github.jokoframework.wilson.cache.entities.ReadOperationEntity;
+import io.github.jokoframework.wilson.cache.repositories.ReadOperationRepository;
+import io.github.jokoframework.wilson.cache.service.ReadOperationService;
+import io.github.jokoframework.wilson.exceptions.ReadOperationException;
+import io.github.jokoframework.wilson.mapper.OrikaBeanMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ReadOperationServiceImpl implements ReadOperationService {
+
+    @Autowired
+    private ReadOperationRepository readRepository;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private OrikaBeanMapper mapper;
+
+    // TODO CREATE APPLICATION CONSTANTS
+    @Value("${wilson.backend.base.url}")
+    private String baseUrl;
+
+    @Override
+    public void insertReadOperation(ReadOperationEntity readOperation) {
+        ReadOperationEntity readOperationEntity = mapper.map(readOperation, ReadOperationEntity.class);
+        readRepository.insert(readOperationEntity);
+    }
+
+    @Override
+    public List<ReadOperationEntity> listReadOperations() {
+        return readRepository.findAll();
+    }
+
+    public void updateReadOperationCache(String uriPathAndQuery) throws ReadOperationException{
+        // A Read Operation is obtained with the uriPathAndQuery (Unique value)
+        Optional<ReadOperationEntity> readOperationEntity = readRepository.findByUri(uriPathAndQuery);
+        if (readOperationEntity.isEmpty()) {
+            throw ReadOperationException.notFound(uriPathAndQuery);
+        }
+
+        // The request defined in the Read Operation is called
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> request = new HttpEntity<>(headers);
+        RestTemplate restTemplate = new RestTemplate();
+
+        ResponseEntity<String> response = restTemplate.exchange(baseUrl + uriPathAndQuery,
+                HttpMethod.GET,
+                request,
+                String.class);
+
+        // A Read Cache is built using the Response and updates the Read Operation's "responseCache" field
+        ReadCacheEntity newCache = new ReadCacheEntity();
+        newCache.setHeaders(response.getHeaders());
+        newCache.setBody(response.getBody());
+        newCache.setStatusCode(response.getStatusCode());
+
+        saveReadCache(readOperationEntity.get().getUri(), newCache);
+    }
+
+    // Pushes a new entry into the cache list of an operation
+    public void saveReadCache(String uri, ReadCacheEntity readCacheEntity) {
+        readCacheEntity.setTimeOfArrival(LocalDateTime.now());
+        mongoTemplate.updateFirst(
+                Query.query(Criteria.where("uri").is(uri)),
+                new Update().set("responseCache", readCacheEntity),
+                ReadOperationEntity.class);
+    }
+}

--- a/src/main/java/io/github/jokoframework/wilson/cache/service/impl/WilsonMasterServiceImpl.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/service/impl/WilsonMasterServiceImpl.java
@@ -1,0 +1,45 @@
+package io.github.jokoframework.wilson.cache.service.impl;
+
+import io.github.jokoframework.wilson.cache.entities.ReadCacheEntity;
+import io.github.jokoframework.wilson.cache.entities.ReadOperationEntity;
+import io.github.jokoframework.wilson.cache.repositories.ReadOperationRepository;
+import io.github.jokoframework.wilson.cache.service.ReadOperationService;
+import io.github.jokoframework.wilson.cache.service.WilsonMasterService;
+import io.github.jokoframework.wilson.mapper.OrikaBeanMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import java.util.Optional;
+
+@Service
+public class WilsonMasterServiceImpl implements WilsonMasterService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WilsonMasterServiceImpl.class);
+
+    @Autowired
+    private ReadOperationRepository readRepository;
+
+    @Autowired
+    ReadOperationService readOperationService;
+
+    @Autowired
+    private OrikaBeanMapper mapper;
+
+    public ResponseEntity<Object> processGetRequest(String uriPathAndQuery) {
+        // A Read Operation is obtained with the uriPathAndQuery (Unique value)
+        Optional<ReadOperationEntity> readOperationEntity = readRepository.findByUri(uriPathAndQuery);
+
+        // If an entry was found and has a Cache entry it will return that otherwise it will try to call the request
+        // right now, update the cache as required and return the response
+        if (readOperationEntity.isPresent() && readOperationEntity.get().getResponseCache() != null) {
+            ReadCacheEntity readCacheEntity = readOperationEntity.get().getResponseCache();
+            return new ResponseEntity<>(readCacheEntity.getBody(), readCacheEntity.getHeaders(), readCacheEntity.getStatusCode());
+        }
+
+        // TODO IMPLEMENT TRYING TO OBTAIN A RESPONSE FROM THE ORIGIN WHEN IT HAS NO CACHE (WETHER HE TRIES TO STORE IT OR NOT!)
+        LOGGER.info("Wilson did not find the Read Operation and still can't call the endpoint in this scenario, its a TODO ¯\\_(ツ)_/¯");
+        return new ResponseEntity<>("Wilson did not find the Read Operation and still can't call the endpoint in this scenario, its a TODO boys", HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/io/github/jokoframework/wilson/config/SpringMongoConfig.java
+++ b/src/main/java/io/github/jokoframework/wilson/config/SpringMongoConfig.java
@@ -1,0 +1,31 @@
+package io.github.jokoframework.wilson.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import com.mongodb.MongoClient;
+
+/**
+ * Spring MongoDB configuration file
+ *
+ */
+@Configuration
+public class SpringMongoConfig{
+
+    @Value("${wilson.mongodb.database.host}")
+    private String dbHost;
+    @Value("${wilson.mongodb.database.port}")
+    private Integer dbPort;
+    @Value("${wilson.mongodb.database.name}")
+    private String dbName;
+
+    public @Bean
+    MongoTemplate mongoTemplate() {
+
+        return new MongoTemplate(new MongoClient(dbHost, dbPort), dbName);
+
+    }
+
+}

--- a/src/main/java/io/github/jokoframework/wilson/constants/ApiPaths.java
+++ b/src/main/java/io/github/jokoframework/wilson/constants/ApiPaths.java
@@ -36,6 +36,20 @@ public class ApiPaths {
     public static final String COUNTRIES = BASE + "/countries";
 
     /**
+     * master route for Wilson's proxy functions
+     */
+    public static final String WILSON_MASTER = BASE + "/master";
+
+    /**
+     * routes for helper endpoints on read operations and read operations cache
+     */
+    public static final String WILSON_INSERT_READ_OPERATION = BASE + "/insert/read-operation";
+
+    public static final String WILSON_LIST_READ_OPERATION = BASE + "/list/read-operation";
+
+    public static final String WILSON_UPDATE_READ_OPERATION_CACHE = BASE + "/update/cache";
+
+    /**
      * routes for people management
      */
     public static final String ROOT_PERSON = API_SECURE + "/person";

--- a/src/main/java/io/github/jokoframework/wilson/exceptions/ReadOperationException.java
+++ b/src/main/java/io/github/jokoframework/wilson/exceptions/ReadOperationException.java
@@ -1,0 +1,28 @@
+package io.github.jokoframework.wilson.exceptions;
+
+import io.github.jokoframework.common.errors.BusinessException;
+
+/**
+ * 
+ * @author bsandoval
+ *
+ */
+public class ReadOperationException extends BusinessException {
+	private static final long serialVersionUID = 1L;
+    public static final String READ_OPERATION_ERROR = "read.operation.error";
+    public static final String READ_OPERATION_NOT_FOUND = READ_OPERATION_ERROR + ".notFound";
+
+    public ReadOperationException(String errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    /**
+     * Builds a Read Operation Not Found Exception
+     *
+     * @param uri read operation uri
+     * @return ReadOperationException
+     */
+    public static ReadOperationException notFound(String uri) {
+        return new ReadOperationException(READ_OPERATION_NOT_FOUND, String.format("Read Operation with URI %s not found" , uri));
+    }
+}

--- a/src/main/java/io/github/jokoframework/wilson/web/controller/ReadOperationController.java
+++ b/src/main/java/io/github/jokoframework/wilson/web/controller/ReadOperationController.java
@@ -1,0 +1,36 @@
+package io.github.jokoframework.wilson.web.controller;
+
+import io.github.jokoframework.wilson.cache.entities.ReadOperationEntity;
+import io.github.jokoframework.wilson.cache.service.ReadOperationService;
+import io.github.jokoframework.wilson.constants.ApiPaths;
+import io.github.jokoframework.wilson.exceptions.ReadOperationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+public class ReadOperationController {
+
+    private final ReadOperationService readOperationService;
+
+    @Autowired
+    public ReadOperationController(ReadOperationService readOperationService){
+        this.readOperationService=readOperationService;
+    }
+
+    @PostMapping(value = ApiPaths.WILSON_INSERT_READ_OPERATION)
+    public void insertReadOperation(@RequestBody ReadOperationEntity readOperationEntity){
+        readOperationService.insertReadOperation(readOperationEntity);
+    }
+
+    @GetMapping(value = ApiPaths.WILSON_LIST_READ_OPERATION)
+    public List<ReadOperationEntity> listReadOperations(){
+        return readOperationService.listReadOperations();
+    }
+
+    @GetMapping(value = ApiPaths.WILSON_UPDATE_READ_OPERATION_CACHE)
+    public void helperSaveReadCache(@RequestParam(value = "service") String service) throws ReadOperationException {
+        readOperationService.updateReadOperationCache(service);
+    }
+}

--- a/src/main/java/io/github/jokoframework/wilson/web/controller/WilsonMasterController.java
+++ b/src/main/java/io/github/jokoframework/wilson/web/controller/WilsonMasterController.java
@@ -1,0 +1,23 @@
+package io.github.jokoframework.wilson.web.controller;
+
+import io.github.jokoframework.wilson.cache.service.WilsonMasterService;
+import io.github.jokoframework.wilson.constants.ApiPaths;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class WilsonMasterController {
+
+    private final WilsonMasterService wilsonMasterService;
+
+    @Autowired
+    public WilsonMasterController(WilsonMasterService wilsonMasterService){
+        this.wilsonMasterService=wilsonMasterService;
+    }
+
+    @GetMapping(value = ApiPaths.WILSON_MASTER)
+    public ResponseEntity<Object> wilsonMasterGetRequest(@RequestParam(value = "service") String service){
+        return wilsonMasterService.processGetRequest(service);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -63,3 +63,13 @@ scheduler.login.cron.timer=*/5 * * * * *
 scheduler.login.url=http://localhost:8085/api/login
 scheduler.login.username=admin
 scheduler.login.password=123456
+
+# Wilson's MongoDB database parameters
+wilson.mongodb.database.host=127.0.0.1
+# Port 27017 is the default MongoDB port
+wilson.mongodb.database.port=27017
+wilson.mongodb.database.name=Wilson
+
+# Base URL for the Backend Wilson communicates with, every URI field in a defined operation will form the full URL
+# by combining: {wilson.backend.base.url}{operation_uri}
+wilson.backend.base.url=http://localhost:9090

--- a/src/main/resources/application.properties.example
+++ b/src/main/resources/application.properties.example
@@ -20,3 +20,13 @@ scheduler.login.cron.timer=*/5 * * * * *
 scheduler.login.url=http://localhost:8085/api/login
 scheduler.login.username=admin
 scheduler.login.password=123456
+
+# Wilson's MongoDB database parameters
+wilson.mongodb.database.host=127.0.0.1
+# Port 27017 is the default MongoDB port
+wilson.mongodb.database.port=27017
+wilson.mongodb.database.name=Wilson
+
+# Base URL for the Backend Wilson communicates with, every URI field in a defined operation will form the full URL
+# by combining: {wilson.backend.base.url}{operation_uri}
+wilson.backend.base.url=http://localhost:9090

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -4,4 +4,10 @@ user.error.notFound=User doesn't exist
 parameter.required=Required parameter not received
 parameter.invalid=Parameter error
 internal.error=Internal error
-user.error.invalid=Invalid user or password 
+user.error.invalid=Invalid user or password
+
+
+# Read Operations
+read.operation.error=Read Operation with URI {0} not found
+
+# Read Cache


### PR DESCRIPTION
- Agrega Endpoint al cual se le pasa el servicio final que se quiere llamar, luego Wilson
ya revisa si tiene en su Cache una entrada que retornar y retorna esta (Si no tiene cache
simplemente no retorna datos, eventualmente deberá llamar al servicio en tiempo real)

- Para las pruebas de esta lectura del Cache se crearon los servicios para Guardar nuevos servicios
de los cuales se quiere mantener un Cache y el servicio para actualizar el Cache de un request en particular (Para este segundo servicio se creo un Endpoint temporal para llamar al servicio)

- Se corrio el Sonar y se arreglaron los problemas que surjieron con mis cambios (Hay muchos otros que arrastramos con el starter-kit que en algún punto debemos tratar de limpiar)