### PR TITLE
Prueba de concepto para el cache de lectura

### DIFF
--- a/RUN.md
+++ b/RUN.md
@@ -8,6 +8,7 @@ https://github.com/jokoframework/joko_backend_starter_kit
 * Maven
 * Java 11 (JDK11)
 * Base de datos PostgreSQL con el nombre *wilson*
+* Base de datos MongoDB
 
 
 ## Clonar proyecto
@@ -111,6 +112,13 @@ Entrar en el directorio de jada proyecto y hacer lo siguiente:
     $ ./scripts/updater update
   ```
     
+# Step 6) Preparar base de datos MongoDB.
+Para guardar los datos sobre que servicios se desea que Wilson aplique sus funcionalidades de Cache y para guardar el cache mismo se utiliza
+una base de datos MongoDB, la configuración de los parametros de conexión a esta base de datos se deben configurar en el application.properties
+
+En el archivo de ejemplo para el application.properties que se encuentra en `src/main/resources/application.properties.examples` se detallan
+campos para definir el HOST, PORT y NAME de la base de datos de MongoDB a la que se conectara Wilson
+
 ## Correr desde una consola con `mvn` (Maven)
 
 Si es una consola nueva exportar las variables primero:
@@ -144,4 +152,3 @@ Esta guía es especifica para estos dos programas pero la mayoría de los IDEs s
 El proyecto cuenta con documentación del API accesible desde el swagger-ui. URI al swagger:
 
 http://localhost:8080/swagger/index.html
-

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <joko-security.version>1.1.2</joko-security.version>
+        <joko-security.version>1.1.3</joko-security.version>
         <joko-utils.version>0.6.1</joko-utils.version>
         <commons-lang3.version>3.1</commons-lang3.version>
         <commons-collections4.version>4.1</commons-collections4.version>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-mongodb</artifactId>
+            <version>2.1.10.RELEASE</version>
+        </dependency>
+
         <!--
         Joko dependencies
         -->

--- a/src/main/java/io/github/jokoframework/wilson/auth/AuthorizationManagerImpl.java
+++ b/src/main/java/io/github/jokoframework/wilson/auth/AuthorizationManagerImpl.java
@@ -47,7 +47,6 @@ public class AuthorizationManagerImpl implements JokoAuthorizationManager {
                 .antMatchers("/h2-console/**").permitAll()
                 .antMatchers("/**/heartbeat").permitAll()
                 .antMatchers(ApiPaths.COUNTRIES).permitAll()
-                .antMatchers(ApiPaths.TEST_GET_STORED_SECRET).permitAll()
                 .antMatchers(ApiPaths.API_SESSIONS).hasAnyAuthority(ADMIN.name())
                 // Users
                 .antMatchers(ApiPaths.ROOT_USERS,
@@ -58,7 +57,7 @@ public class AuthorizationManagerImpl implements JokoAuthorizationManager {
                 .antMatchers(ApiPaths.WILSON_MASTER,
                         ApiPaths.WILSON_INSERT_READ_OPERATION,
                         ApiPaths.WILSON_LIST_READ_OPERATION,
-                        ApiPaths.WILSON_UPDATE_READ_OPERATION_CACHE).permitAll();
+                        ApiPaths.WILSON_UPDATE_READ_OPERATION_CACHE).hasAnyAuthority(ADMIN.name());
 
         // Only in dev profile,
         // Allows X-Frame-Options headers sent by H2 console.

--- a/src/main/java/io/github/jokoframework/wilson/auth/AuthorizationManagerImpl.java
+++ b/src/main/java/io/github/jokoframework/wilson/auth/AuthorizationManagerImpl.java
@@ -53,7 +53,12 @@ public class AuthorizationManagerImpl implements JokoAuthorizationManager {
                 .antMatchers(ApiPaths.ROOT_USERS,
                         ApiPaths.USERS_HEARTBEAT,
                         ApiPaths.USERS_BY_NAME,
-                        ApiPaths.USERS_CSV).hasAnyAuthority(ADMIN.name());
+                        ApiPaths.USERS_CSV).hasAnyAuthority(ADMIN.name())
+                // Wilson
+                .antMatchers(ApiPaths.WILSON_MASTER,
+                        ApiPaths.WILSON_INSERT_READ_OPERATION,
+                        ApiPaths.WILSON_LIST_READ_OPERATION,
+                        ApiPaths.WILSON_UPDATE_READ_OPERATION_CACHE).permitAll();
 
         // Only in dev profile,
         // Allows X-Frame-Options headers sent by H2 console.

--- a/src/main/java/io/github/jokoframework/wilson/cache/entities/ReadCacheEntity.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/entities/ReadCacheEntity.java
@@ -1,0 +1,59 @@
+package io.github.jokoframework.wilson.cache.entities;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+public class ReadCacheEntity implements Serializable {
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime timeOfArrival;
+    private HttpHeaders headers;
+    private String body;
+    private HttpStatus statusCode;
+
+    public LocalDateTime getTimeOfArrival() {
+        return timeOfArrival;
+    }
+
+    public void setTimeOfArrival(LocalDateTime timeOfArrival) {
+        this.timeOfArrival = timeOfArrival;
+    }
+
+    public HttpHeaders getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(HttpHeaders headers) {
+        this.headers = headers;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public HttpStatus getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(HttpStatus statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("timeOfArrival", timeOfArrival)
+                .append("headers", headers)
+                .append("body", body)
+                .append("statusCode", statusCode)
+                .toString();
+    }
+}

--- a/src/main/java/io/github/jokoframework/wilson/cache/entities/ReadOperationEntity.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/entities/ReadOperationEntity.java
@@ -2,8 +2,9 @@ package io.github.jokoframework.wilson.cache.entities;
 
 import io.github.jokoframework.wilson.cache.enums.ReadOperationHttpVerbEnum;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
-import org.springframework.data.mongodb.core.mapping.Field;
 
 import javax.persistence.Id;
 import java.io.Serializable;
@@ -11,19 +12,28 @@ import java.io.Serializable;
 @Document("readOperation")
 public class ReadOperationEntity implements Serializable {
     @Id
-    @Field("_id")
-    private String uri;
+    private ObjectId id;
+    @Indexed(unique = true)
+    private String resource;
     private ReadOperationHttpVerbEnum requestType;
     private Integer retryTimer;
     private Integer maxAge;
     private ReadCacheEntity responseCache;
 
-    public String getUri() {
-        return uri;
+    public ObjectId getId() {
+        return id;
     }
 
-    public void setUri(String uri) {
-        this.uri = uri;
+    public void setId(ObjectId id) {
+        this.id = id;
+    }
+
+    public String getResource() {
+        return resource;
+    }
+
+    public void setResource(String resource) {
+        this.resource = resource;
     }
 
     public ReadOperationHttpVerbEnum getRequestType() {
@@ -61,8 +71,8 @@ public class ReadOperationEntity implements Serializable {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .appendSuper(super.toString())
-                .append("uri", uri)
+                .append("id", id)
+                .append("resource", resource)
                 .append("requestType", requestType)
                 .append("retryTimer", retryTimer)
                 .append("maxAge", maxAge)

--- a/src/main/java/io/github/jokoframework/wilson/cache/entities/ReadOperationEntity.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/entities/ReadOperationEntity.java
@@ -1,0 +1,72 @@
+package io.github.jokoframework.wilson.cache.entities;
+
+import io.github.jokoframework.wilson.cache.enums.ReadOperationHttpVerbEnum;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import javax.persistence.Id;
+import java.io.Serializable;
+
+@Document("readOperation")
+public class ReadOperationEntity implements Serializable {
+    @Id
+    @Field("_id")
+    private String uri;
+    private ReadOperationHttpVerbEnum requestType;
+    private Integer retryTimer;
+    private Integer maxAge;
+    private ReadCacheEntity responseCache;
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public ReadOperationHttpVerbEnum getRequestType() {
+        return requestType;
+    }
+
+    public void setRequestType(ReadOperationHttpVerbEnum requestType) {
+        this.requestType = requestType;
+    }
+
+    public Integer getRetryTimer() {
+        return retryTimer;
+    }
+
+    public void setRetryTimer(Integer retryTimer) {
+        this.retryTimer = retryTimer;
+    }
+
+    public Integer getMaxAge() {
+        return maxAge;
+    }
+
+    public void setMaxAge(Integer maxAge) {
+        this.maxAge = maxAge;
+    }
+
+    public ReadCacheEntity getResponseCache() {
+        return responseCache;
+    }
+
+    public void setResponseCache(ReadCacheEntity responseCache) {
+        this.responseCache = responseCache;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .appendSuper(super.toString())
+                .append("uri", uri)
+                .append("requestType", requestType)
+                .append("retryTimer", retryTimer)
+                .append("maxAge", maxAge)
+                .append("responseCache", responseCache)
+                .toString();
+    }
+}

--- a/src/main/java/io/github/jokoframework/wilson/cache/enums/ReadOperationHttpVerbEnum.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/enums/ReadOperationHttpVerbEnum.java
@@ -1,0 +1,5 @@
+package io.github.jokoframework.wilson.cache.enums;
+
+public enum ReadOperationHttpVerbEnum {
+    GET
+}

--- a/src/main/java/io/github/jokoframework/wilson/cache/repositories/ReadOperationRepository.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/repositories/ReadOperationRepository.java
@@ -1,0 +1,17 @@
+package io.github.jokoframework.wilson.cache.repositories;
+
+import io.github.jokoframework.wilson.cache.entities.ReadOperationEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReadOperationRepository extends MongoRepository<ReadOperationEntity, String> {
+
+    public ReadOperationEntity insert(ReadOperationEntity readOperationEntity);
+
+    public List<ReadOperationEntity> findAll();
+
+    public Optional<ReadOperationEntity> findByUri(String uri);
+
+}

--- a/src/main/java/io/github/jokoframework/wilson/cache/repositories/ReadOperationRepository.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/repositories/ReadOperationRepository.java
@@ -12,6 +12,6 @@ public interface ReadOperationRepository extends MongoRepository<ReadOperationEn
 
     public List<ReadOperationEntity> findAll();
 
-    public Optional<ReadOperationEntity> findByUri(String uri);
+    public Optional<ReadOperationEntity> findByResource(String resource);
 
 }

--- a/src/main/java/io/github/jokoframework/wilson/cache/service/ReadOperationService.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/service/ReadOperationService.java
@@ -1,0 +1,22 @@
+package io.github.jokoframework.wilson.cache.service;
+
+import io.github.jokoframework.wilson.cache.entities.ReadCacheEntity;
+import io.github.jokoframework.wilson.cache.entities.ReadOperationEntity;
+import io.github.jokoframework.wilson.exceptions.ReadOperationException;
+
+import java.util.List;
+
+public interface ReadOperationService {
+
+    // ReadOperation services
+    public void insertReadOperation(ReadOperationEntity readOperationEntity);
+
+    public List<ReadOperationEntity> listReadOperations();
+
+    // Insert Test Data for a GET request
+    public void updateReadOperationCache(String service) throws ReadOperationException;
+
+    // ReadCache services
+    public void saveReadCache(String uri, ReadCacheEntity newCache);
+
+}

--- a/src/main/java/io/github/jokoframework/wilson/cache/service/WilsonMasterService.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/service/WilsonMasterService.java
@@ -1,0 +1,10 @@
+package io.github.jokoframework.wilson.cache.service;
+
+import org.springframework.http.ResponseEntity;
+
+public interface WilsonMasterService {
+
+    // Process GET requests from the Frontend, applying Cache functions if available
+    public ResponseEntity<Object> processGetRequest(String service);
+
+}

--- a/src/main/java/io/github/jokoframework/wilson/cache/service/WilsonMasterService.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/service/WilsonMasterService.java
@@ -5,6 +5,6 @@ import org.springframework.http.ResponseEntity;
 public interface WilsonMasterService {
 
     // Process GET requests from the Frontend, applying Cache functions if available
-    public ResponseEntity<Object> processGetRequest(String service);
+    public ResponseEntity<Object> processGetRequest(String resource);
 
 }

--- a/src/main/java/io/github/jokoframework/wilson/cache/service/impl/ReadOperationServiceImpl.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/service/impl/ReadOperationServiceImpl.java
@@ -6,6 +6,7 @@ import io.github.jokoframework.wilson.cache.repositories.ReadOperationRepository
 import io.github.jokoframework.wilson.cache.service.ReadOperationService;
 import io.github.jokoframework.wilson.exceptions.ReadOperationException;
 import io.github.jokoframework.wilson.mapper.OrikaBeanMapper;
+import io.github.jokoframework.wilson.scheduler.ScheduledTasks;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -38,8 +39,7 @@ public class ReadOperationServiceImpl implements ReadOperationService {
 
     @Override
     public void insertReadOperation(ReadOperationEntity readOperation) {
-        ReadOperationEntity readOperationEntity = mapper.map(readOperation, ReadOperationEntity.class);
-        readRepository.insert(readOperationEntity);
+        readRepository.insert(readOperation);
     }
 
     @Override
@@ -47,20 +47,26 @@ public class ReadOperationServiceImpl implements ReadOperationService {
         return readRepository.findAll();
     }
 
-    public void updateReadOperationCache(String uriPathAndQuery) throws ReadOperationException{
-        // A Read Operation is obtained with the uriPathAndQuery (Unique value)
-        Optional<ReadOperationEntity> readOperationEntity = readRepository.findByUri(uriPathAndQuery);
+    public void updateReadOperationCache(String resource) throws ReadOperationException{
+        // A Read Operation is obtained with the resource field (Unique value)
+        Optional<ReadOperationEntity> readOperationEntity = readRepository.findByResource(resource);
         if (readOperationEntity.isEmpty()) {
-            throw ReadOperationException.notFound(uriPathAndQuery);
+            throw ReadOperationException.notFound(resource);
         }
 
-        // The request defined in the Read Operation is called
+        // The request defined in the Read Operation is built and called
         HttpHeaders headers = new HttpHeaders();
+
+        // TODO MOVE INJECTING THE SECRET INTO HEADER TO A RestTemplate INTERCEPTOR
+        if (ScheduledTasks.getAccessToken() != null) {
+            headers.add("X-JOKO-AUTH", ScheduledTasks.getAccessToken());
+        }
+
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<String> request = new HttpEntity<>(headers);
         RestTemplate restTemplate = new RestTemplate();
 
-        ResponseEntity<String> response = restTemplate.exchange(baseUrl + uriPathAndQuery,
+        ResponseEntity<String> response = restTemplate.exchange(baseUrl + resource,
                 HttpMethod.GET,
                 request,
                 String.class);
@@ -71,14 +77,14 @@ public class ReadOperationServiceImpl implements ReadOperationService {
         newCache.setBody(response.getBody());
         newCache.setStatusCode(response.getStatusCode());
 
-        saveReadCache(readOperationEntity.get().getUri(), newCache);
+        saveReadCache(readOperationEntity.get().getResource(), newCache);
     }
 
     // Pushes a new entry into the cache list of an operation
-    public void saveReadCache(String uri, ReadCacheEntity readCacheEntity) {
+    public void saveReadCache(String resource, ReadCacheEntity readCacheEntity) {
         readCacheEntity.setTimeOfArrival(LocalDateTime.now());
         mongoTemplate.updateFirst(
-                Query.query(Criteria.where("uri").is(uri)),
+                Query.query(Criteria.where("resource").is(resource)),
                 new Update().set("responseCache", readCacheEntity),
                 ReadOperationEntity.class);
     }

--- a/src/main/java/io/github/jokoframework/wilson/cache/service/impl/ReadOperationServiceImpl.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/service/impl/ReadOperationServiceImpl.java
@@ -1,0 +1,85 @@
+package io.github.jokoframework.wilson.cache.service.impl;
+
+import io.github.jokoframework.wilson.cache.entities.ReadCacheEntity;
+import io.github.jokoframework.wilson.cache.entities.ReadOperationEntity;
+import io.github.jokoframework.wilson.cache.repositories.ReadOperationRepository;
+import io.github.jokoframework.wilson.cache.service.ReadOperationService;
+import io.github.jokoframework.wilson.exceptions.ReadOperationException;
+import io.github.jokoframework.wilson.mapper.OrikaBeanMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ReadOperationServiceImpl implements ReadOperationService {
+
+    @Autowired
+    private ReadOperationRepository readRepository;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private OrikaBeanMapper mapper;
+
+    // TODO CREATE APPLICATION CONSTANTS
+    @Value("${wilson.backend.base.url}")
+    private String baseUrl;
+
+    @Override
+    public void insertReadOperation(ReadOperationEntity readOperation) {
+        ReadOperationEntity readOperationEntity = mapper.map(readOperation, ReadOperationEntity.class);
+        readRepository.insert(readOperationEntity);
+    }
+
+    @Override
+    public List<ReadOperationEntity> listReadOperations() {
+        return readRepository.findAll();
+    }
+
+    public void updateReadOperationCache(String uriPathAndQuery) throws ReadOperationException{
+        // A Read Operation is obtained with the uriPathAndQuery (Unique value)
+        Optional<ReadOperationEntity> readOperationEntity = readRepository.findByUri(uriPathAndQuery);
+        if (readOperationEntity.isEmpty()) {
+            throw ReadOperationException.notFound(uriPathAndQuery);
+        }
+
+        // The request defined in the Read Operation is called
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> request = new HttpEntity<>(headers);
+        RestTemplate restTemplate = new RestTemplate();
+
+        ResponseEntity<String> response = restTemplate.exchange(baseUrl + uriPathAndQuery,
+                HttpMethod.GET,
+                request,
+                String.class);
+
+        // A Read Cache is built using the Response and updates the Read Operation's "responseCache" field
+        ReadCacheEntity newCache = new ReadCacheEntity();
+        newCache.setHeaders(response.getHeaders());
+        newCache.setBody(response.getBody());
+        newCache.setStatusCode(response.getStatusCode());
+
+        saveReadCache(readOperationEntity.get().getUri(), newCache);
+    }
+
+    // Pushes a new entry into the cache list of an operation
+    public void saveReadCache(String uri, ReadCacheEntity readCacheEntity) {
+        readCacheEntity.setTimeOfArrival(LocalDateTime.now());
+        mongoTemplate.updateFirst(
+                Query.query(Criteria.where("uri").is(uri)),
+                new Update().set("responseCache", readCacheEntity),
+                ReadOperationEntity.class);
+    }
+}

--- a/src/main/java/io/github/jokoframework/wilson/cache/service/impl/WilsonMasterServiceImpl.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/service/impl/WilsonMasterServiceImpl.java
@@ -1,0 +1,45 @@
+package io.github.jokoframework.wilson.cache.service.impl;
+
+import io.github.jokoframework.wilson.cache.entities.ReadCacheEntity;
+import io.github.jokoframework.wilson.cache.entities.ReadOperationEntity;
+import io.github.jokoframework.wilson.cache.repositories.ReadOperationRepository;
+import io.github.jokoframework.wilson.cache.service.ReadOperationService;
+import io.github.jokoframework.wilson.cache.service.WilsonMasterService;
+import io.github.jokoframework.wilson.mapper.OrikaBeanMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import java.util.Optional;
+
+@Service
+public class WilsonMasterServiceImpl implements WilsonMasterService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WilsonMasterServiceImpl.class);
+
+    @Autowired
+    private ReadOperationRepository readRepository;
+
+    @Autowired
+    ReadOperationService readOperationService;
+
+    @Autowired
+    private OrikaBeanMapper mapper;
+
+    public ResponseEntity<Object> processGetRequest(String uriPathAndQuery) {
+        // A Read Operation is obtained with the uriPathAndQuery (Unique value)
+        Optional<ReadOperationEntity> readOperationEntity = readRepository.findByUri(uriPathAndQuery);
+
+        // If an entry was found and has a Cache entry it will return that otherwise it will try to call the request
+        // right now, update the cache as required and return the response
+        if (readOperationEntity.isPresent() && readOperationEntity.get().getResponseCache() != null) {
+            ReadCacheEntity readCacheEntity = readOperationEntity.get().getResponseCache();
+            return new ResponseEntity<>(readCacheEntity.getBody(), readCacheEntity.getHeaders(), readCacheEntity.getStatusCode());
+        }
+
+        // TODO IMPLEMENT TRYING TO OBTAIN A RESPONSE FROM THE ORIGIN WHEN IT HAS NO CACHE (WETHER HE TRIES TO STORE IT OR NOT!)
+        LOGGER.info("Wilson did not find the Read Operation and still can't call the endpoint in this scenario, its a TODO ¯\\_(ツ)_/¯");
+        return new ResponseEntity<>("Wilson did not find the Read Operation and still can't call the endpoint in this scenario, its a TODO boys", HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/io/github/jokoframework/wilson/cache/service/impl/WilsonMasterServiceImpl.java
+++ b/src/main/java/io/github/jokoframework/wilson/cache/service/impl/WilsonMasterServiceImpl.java
@@ -27,9 +27,9 @@ public class WilsonMasterServiceImpl implements WilsonMasterService {
     @Autowired
     private OrikaBeanMapper mapper;
 
-    public ResponseEntity<Object> processGetRequest(String uriPathAndQuery) {
-        // A Read Operation is obtained with the uriPathAndQuery (Unique value)
-        Optional<ReadOperationEntity> readOperationEntity = readRepository.findByUri(uriPathAndQuery);
+    public ResponseEntity<Object> processGetRequest(String resource) {
+        // A Read Operation is obtained with the resource (Unique value)
+        Optional<ReadOperationEntity> readOperationEntity = readRepository.findByResource(resource);
 
         // If an entry was found and has a Cache entry it will return that otherwise it will try to call the request
         // right now, update the cache as required and return the response
@@ -39,7 +39,7 @@ public class WilsonMasterServiceImpl implements WilsonMasterService {
         }
 
         // TODO IMPLEMENT TRYING TO OBTAIN A RESPONSE FROM THE ORIGIN WHEN IT HAS NO CACHE (WETHER HE TRIES TO STORE IT OR NOT!)
-        LOGGER.info("Wilson did not find the Read Operation and still can't call the endpoint in this scenario, its a TODO ¯\\_(ツ)_/¯");
-        return new ResponseEntity<>("Wilson did not find the Read Operation and still can't call the endpoint in this scenario, its a TODO boys", HttpStatus.NO_CONTENT);
+        LOGGER.info("Wilson did not find the Read Operation and still can't call the endpoint in this scenario");
+        return new ResponseEntity<>("Wilson did not find the Read Operation and still can't call the endpoint in this scenario", HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/io/github/jokoframework/wilson/config/SpringMongoConfig.java
+++ b/src/main/java/io/github/jokoframework/wilson/config/SpringMongoConfig.java
@@ -1,0 +1,31 @@
+package io.github.jokoframework.wilson.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import com.mongodb.MongoClient;
+
+/**
+ * Spring MongoDB configuration file
+ *
+ */
+@Configuration
+public class SpringMongoConfig{
+
+    @Value("${wilson.mongodb.database.host}")
+    private String dbHost;
+    @Value("${wilson.mongodb.database.port}")
+    private Integer dbPort;
+    @Value("${wilson.mongodb.database.name}")
+    private String dbName;
+
+    public @Bean
+    MongoTemplate mongoTemplate() {
+
+        return new MongoTemplate(new MongoClient(dbHost, dbPort), dbName);
+
+    }
+
+}

--- a/src/main/java/io/github/jokoframework/wilson/constants/ApiPaths.java
+++ b/src/main/java/io/github/jokoframework/wilson/constants/ApiPaths.java
@@ -36,6 +36,20 @@ public class ApiPaths {
     public static final String COUNTRIES = BASE + "/countries";
 
     /**
+     * master route for Wilson's proxy functions
+     */
+    public static final String WILSON_MASTER = BASE + "/master";
+
+    /**
+     * routes for helper endpoints on read operations and read operations cache
+     */
+    public static final String WILSON_INSERT_READ_OPERATION = BASE + "/insert/read-operation";
+
+    public static final String WILSON_LIST_READ_OPERATION = BASE + "/list/read-operation";
+
+    public static final String WILSON_UPDATE_READ_OPERATION_CACHE = BASE + "/update/cache";
+
+    /**
      * routes for people management
      */
     public static final String ROOT_PERSON = API_SECURE + "/person";

--- a/src/main/java/io/github/jokoframework/wilson/exceptions/ReadOperationException.java
+++ b/src/main/java/io/github/jokoframework/wilson/exceptions/ReadOperationException.java
@@ -1,0 +1,28 @@
+package io.github.jokoframework.wilson.exceptions;
+
+import io.github.jokoframework.common.errors.BusinessException;
+
+/**
+ * 
+ * @author bsandoval
+ *
+ */
+public class ReadOperationException extends BusinessException {
+	private static final long serialVersionUID = 1L;
+    public static final String READ_OPERATION_ERROR = "read.operation.error";
+    public static final String READ_OPERATION_NOT_FOUND = READ_OPERATION_ERROR + ".notFound";
+
+    public ReadOperationException(String errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    /**
+     * Builds a Read Operation Not Found Exception
+     *
+     * @param uri read operation uri
+     * @return ReadOperationException
+     */
+    public static ReadOperationException notFound(String uri) {
+        return new ReadOperationException(READ_OPERATION_NOT_FOUND, String.format("Read Operation with URI %s not found" , uri));
+    }
+}

--- a/src/main/java/io/github/jokoframework/wilson/scheduler/ScheduledTasks.java
+++ b/src/main/java/io/github/jokoframework/wilson/scheduler/ScheduledTasks.java
@@ -1,36 +1,48 @@
 package io.github.jokoframework.wilson.scheduler;
 
 import java.text.SimpleDateFormat;
+import java.util.List;
 
+import io.github.jokoframework.wilson.cache.entities.ReadOperationEntity;
+import io.github.jokoframework.wilson.cache.service.ReadOperationService;
+import io.github.jokoframework.wilson.exceptions.ReadOperationException;
 import io.github.jokoframework.wilson.scheduler.dto.LoginRequestDTO;
 import io.github.jokoframework.wilson.scheduler.dto.LoginResponseDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 @Component
 public class ScheduledTasks {
 
+    @Autowired
+    private ReadOperationService readOperationService;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ScheduledTasks.class);
     private final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
 
     @Value("${scheduler.login.url}")
-    private String loginUrl;
+    private String refreshTokenUrl;
     @Value("${scheduler.login.username}")
     private String loginUsername;
     @Value("${scheduler.login.password}")
     private String loginPassword;
+    @Value("${scheduler.access.token.url}")
+    private String accessTokenUrl;
 
-    private static String secret;
+    private static String refreshToken;
+    private static String accessToken;
 
     @Scheduled(cron = "${scheduler.login.cron.timer}")
     public void refreshLogin() {
-        // We build the request we want to send
+        // Login request is built to obtain/refresh the Refresh Token
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
 
@@ -38,35 +50,81 @@ public class ScheduledTasks {
         credentials.setUsername(loginUsername);
         credentials.setPassword(loginPassword);
 
-
-        HttpEntity<LoginRequestDTO> request = new HttpEntity<>(credentials, headers);
-
         // We make the request, logging response data and managing some types of exceptions
         RestTemplate restTemplate = new RestTemplate();
         try {
-            ResponseEntity<LoginResponseDTO> response = restTemplate.exchange(loginUrl,
+            ResponseEntity<LoginResponseDTO> response = restTemplate.exchange(refreshTokenUrl,
                     HttpMethod.POST,
-                    request,
+                    new HttpEntity<>(credentials, headers),
                     LoginResponseDTO.class);
 
-            // Secret is updated
+            // Refresh Token is updated
             if (response.getBody().getSecret() != null) {
-                setSecret(response.getBody().getSecret());
+                setRefreshToken(response.getBody().getSecret());
                 String expiration = dateFormat.format(response.getBody().getExpiration());
-                LOGGER.info("LOGIN SERVICE WAS REACHED - REFRESHED SECRET - EXPIRES ON = {}", expiration);
+                LOGGER.info("REFRESH TOKEN SERVICE WAS REACHED - TOKEN RENEWED - EXPIRES ON = {}", expiration);
             } else {
-                LOGGER.info("LOGIN SERVICE WAS REACHED - SECRET WAS NOT RETURNED BY SERVICE?");
+                LOGGER.info("REFRESH TOKEN SERVICE WAS REACHED - SECRET WAS NOT RETURNED BY SERVICE?");
             }
         } catch (ResourceAccessException e) {
-            LOGGER.info("LOGIN SERVICE COULD NOT BE REACHED");
+            LOGGER.info("REFRESH TOKEN SERVICE COULD NOT BE REACHED");
+        }
+        try {
+            headers.add("X-JOKO-AUTH", refreshToken);
+            ResponseEntity<LoginResponseDTO> response = restTemplate.exchange(accessTokenUrl,
+                    HttpMethod.POST,
+                    new HttpEntity<>(headers),
+                    LoginResponseDTO.class);
+
+            // Access Token is updated
+            if (response.getBody().getSecret() != null) {
+                setAccessToken(response.getBody().getSecret());
+                String expiration = dateFormat.format(response.getBody().getExpiration());
+                LOGGER.info("ACCESS TOKEN SERVICE WAS REACHED - TOKEN RENEWED - EXPIRES ON = {}", expiration);
+            } else {
+                LOGGER.info("ACCESS TOKEN SERVICE WAS REACHED - SECRET WAS NOT RETURNED BY SERVICE?");
+            }
+        } catch (ResourceAccessException e) {
+            LOGGER.info("ACCESS TOKEN SERVICE COULD NOT BE REACHED");
         }
     }
 
-    public static void setSecret(String secret) {
-        ScheduledTasks.secret = secret;
+    @Scheduled(cron = "${scheduler.update.read.cache.cron.timer}")
+    public void refreshReadCache() {
+        System.out.println("");
+        LOGGER.info("STARTING REFRESH READ CACHE METHOD");
+        List<ReadOperationEntity> readOperations = readOperationService.listReadOperations();
+        if (readOperations.size() == 0) {
+            LOGGER.info("THERE ARE NO READ OPERATIONS IN THE DATABASE");
+        }
+        for (ReadOperationEntity readOperation : readOperations) {
+            try {
+                readOperationService.updateReadOperationCache(readOperation.getResource());
+                LOGGER.info("SUCCESS - UPDATE FOR RESOURCE = {}", readOperation.getResource());
+            } catch (ReadOperationException | ResourceAccessException | HttpClientErrorException e) {
+                LOGGER.info("FAILURE - UPDATE FOR RESOURCE = {}", readOperation.getResource());
+                LOGGER.error(e.toString());
+            }
+        }
+
+        LOGGER.info("ENDING REFRESH READ CACHE METHOD");
+        System.out.println("");
     }
 
-    public static String getSecret() {
-        return secret;
+    // Private Setters and Public Getters
+    public static String getRefreshToken() {
+        return refreshToken;
+    }
+
+    private static void setRefreshToken(String refreshToken) {
+        ScheduledTasks.refreshToken = refreshToken;
+    }
+
+    public static String getAccessToken() {
+        return accessToken;
+    }
+
+    private static void setAccessToken(String accessToken) {
+        ScheduledTasks.accessToken = accessToken;
     }
 }

--- a/src/main/java/io/github/jokoframework/wilson/web/controller/BaseRestController.java
+++ b/src/main/java/io/github/jokoframework/wilson/web/controller/BaseRestController.java
@@ -1,7 +1,6 @@
 package io.github.jokoframework.wilson.web.controller;
 
 import io.github.jokoframework.wilson.constants.ApiPaths;
-import io.github.jokoframework.wilson.scheduler.ScheduledTasks;
 import io.github.jokoframework.wilson.web.response.HeartBeatResponseDTO;
 import io.github.jokoframework.wilson.web.session.SessionManager;
 import io.github.jokoframework.wilson.web.session.UserCurrentInfo;
@@ -10,7 +9,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
@@ -32,11 +30,6 @@ public abstract class BaseRestController {
     public ResponseEntity<HeartBeatResponseDTO> getHearbeat() {
         HeartBeatResponseDTO heartBeatResponseDTO = getHeartBeatStatus();
         return new ResponseEntity<>(heartBeatResponseDTO, heartBeatResponseDTO.getHttpStatus());
-    }
-
-    @GetMapping(value = ApiPaths.TEST_GET_STORED_SECRET)
-    public String getStoredSecret() {
-        return ScheduledTasks.getSecret();
     }
 
     public HeartBeatResponseDTO getHeartBeatStatus() {

--- a/src/main/java/io/github/jokoframework/wilson/web/controller/ReadOperationController.java
+++ b/src/main/java/io/github/jokoframework/wilson/web/controller/ReadOperationController.java
@@ -1,0 +1,36 @@
+package io.github.jokoframework.wilson.web.controller;
+
+import io.github.jokoframework.wilson.cache.entities.ReadOperationEntity;
+import io.github.jokoframework.wilson.cache.service.ReadOperationService;
+import io.github.jokoframework.wilson.constants.ApiPaths;
+import io.github.jokoframework.wilson.exceptions.ReadOperationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+public class ReadOperationController {
+
+    private final ReadOperationService readOperationService;
+
+    @Autowired
+    public ReadOperationController(ReadOperationService readOperationService){
+        this.readOperationService=readOperationService;
+    }
+
+    @PostMapping(value = ApiPaths.WILSON_INSERT_READ_OPERATION)
+    public void insertReadOperation(@RequestBody ReadOperationEntity readOperationEntity){
+        readOperationService.insertReadOperation(readOperationEntity);
+    }
+
+    @GetMapping(value = ApiPaths.WILSON_LIST_READ_OPERATION)
+    public List<ReadOperationEntity> listReadOperations(){
+        return readOperationService.listReadOperations();
+    }
+
+    @GetMapping(value = ApiPaths.WILSON_UPDATE_READ_OPERATION_CACHE)
+    public void helperSaveReadCache(@RequestParam(value = "service") String service) throws ReadOperationException {
+        readOperationService.updateReadOperationCache(service);
+    }
+}

--- a/src/main/java/io/github/jokoframework/wilson/web/controller/WilsonMasterController.java
+++ b/src/main/java/io/github/jokoframework/wilson/web/controller/WilsonMasterController.java
@@ -17,7 +17,7 @@ public class WilsonMasterController {
     }
 
     @GetMapping(value = ApiPaths.WILSON_MASTER)
-    public ResponseEntity<Object> wilsonMasterGetRequest(@RequestParam(value = "service") String service){
-        return wilsonMasterService.processGetRequest(service);
+    public ResponseEntity<Object> wilsonMasterGetRequest(@RequestParam(value = "resource") String resource){
+        return wilsonMasterService.processGetRequest(resource);
     }
 }

--- a/src/main/java/io/github/jokoframework/wilson/web/controller/WilsonMasterController.java
+++ b/src/main/java/io/github/jokoframework/wilson/web/controller/WilsonMasterController.java
@@ -1,0 +1,23 @@
+package io.github.jokoframework.wilson.web.controller;
+
+import io.github.jokoframework.wilson.cache.service.WilsonMasterService;
+import io.github.jokoframework.wilson.constants.ApiPaths;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class WilsonMasterController {
+
+    private final WilsonMasterService wilsonMasterService;
+
+    @Autowired
+    public WilsonMasterController(WilsonMasterService wilsonMasterService){
+        this.wilsonMasterService=wilsonMasterService;
+    }
+
+    @GetMapping(value = ApiPaths.WILSON_MASTER)
+    public ResponseEntity<Object> wilsonMasterGetRequest(@RequestParam(value = "service") String service){
+        return wilsonMasterService.processGetRequest(service);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -59,8 +59,10 @@ management.security.roles=END_USER, ADMIN
 
 # Data used by the scheduler Worker to Login to a JWT secured server
 # Cron String to define how often is the Login service reached
-scheduler.login.cron.timer=*/5 * * * * *
-scheduler.login.url=http://localhost:8085/api/login
+scheduler.login.cron.timer=*/30 * * * * *
+scheduler.update.read.cache.cron.timer=*/5 * * * * *
+scheduler.login.url=http://localhost:9090/api/login
+scheduler.access.token.url=http://localhost:9090/api/token/user-access
 scheduler.login.username=admin
 scheduler.login.password=123456
 
@@ -70,6 +72,6 @@ wilson.mongodb.database.host=127.0.0.1
 wilson.mongodb.database.port=27017
 wilson.mongodb.database.name=Wilson
 
-# Base URL for the Backend Wilson communicates with, every URI field in a defined operation will form the full URL
-# by combining: {wilson.backend.base.url}{operation_uri}
+# Backend Base URL that Wilson communicates with, every RESOURCE field in a defined operation will form the full URL
+# by combining: {wilson.backend.base.url}{resource}
 wilson.backend.base.url=http://localhost:9090

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -63,3 +63,13 @@ scheduler.login.cron.timer=*/5 * * * * *
 scheduler.login.url=http://localhost:8085/api/login
 scheduler.login.username=admin
 scheduler.login.password=123456
+
+# Wilson's MongoDB database parameters
+wilson.mongodb.database.host=127.0.0.1
+# Port 27017 is the default MongoDB port
+wilson.mongodb.database.port=27017
+wilson.mongodb.database.name=Wilson
+
+# Base URL for the Backend Wilson communicates with, every URI field in a defined operation will form the full URL
+# by combining: {wilson.backend.base.url}{operation_uri}
+wilson.backend.base.url=http://localhost:9090

--- a/src/main/resources/application.properties.example
+++ b/src/main/resources/application.properties.example
@@ -20,3 +20,13 @@ scheduler.login.cron.timer=*/5 * * * * *
 scheduler.login.url=http://localhost:8085/api/login
 scheduler.login.username=admin
 scheduler.login.password=123456
+
+# Wilson's MongoDB database parameters
+wilson.mongodb.database.host=127.0.0.1
+# Port 27017 is the default MongoDB port
+wilson.mongodb.database.port=27017
+wilson.mongodb.database.name=Wilson
+
+# Base URL for the Backend Wilson communicates with, every URI field in a defined operation will form the full URL
+# by combining: {wilson.backend.base.url}{operation_uri}
+wilson.backend.base.url=http://localhost:9090

--- a/src/main/resources/application.properties.example
+++ b/src/main/resources/application.properties.example
@@ -16,8 +16,10 @@ spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
 
 # Data used by the scheduler Worker to Login to a JWT secured server
 # Cron String to define how often is the Login service reached
-scheduler.login.cron.timer=*/5 * * * * *
-scheduler.login.url=http://localhost:8085/api/login
+scheduler.login.cron.timer=*/30 * * * * *
+scheduler.update.read.cache.cron.timer=*/5 * * * * *
+scheduler.login.url=http://localhost:9090/api/login
+scheduler.access.token.url=http://localhost:9090/api/token/user-access
 scheduler.login.username=admin
 scheduler.login.password=123456
 
@@ -27,6 +29,6 @@ wilson.mongodb.database.host=127.0.0.1
 wilson.mongodb.database.port=27017
 wilson.mongodb.database.name=Wilson
 
-# Base URL for the Backend Wilson communicates with, every URI field in a defined operation will form the full URL
-# by combining: {wilson.backend.base.url}{operation_uri}
+# Backend Base URL that Wilson communicates with, every RESOURCE field in a defined operation will form the full URL
+# by combining: {wilson.backend.base.url}{resource}
 wilson.backend.base.url=http://localhost:9090

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -8,6 +8,6 @@ user.error.invalid=Invalid user or password
 
 
 # Read Operations
-read.operation.error=Read Operation with URI {0} not found
+read.operation.error=Read Operation with RESOURCE {0} not found
 
 # Read Cache

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -4,4 +4,10 @@ user.error.notFound=User doesn't exist
 parameter.required=Required parameter not received
 parameter.invalid=Parameter error
 internal.error=Internal error
-user.error.invalid=Invalid user or password 
+user.error.invalid=Invalid user or password
+
+
+# Read Operations
+read.operation.error=Read Operation with URI {0} not found
+
+# Read Cache


### PR DESCRIPTION
- Modifica Worker de Sesión para que obtenga el Access Token ademas del Refresh Token (De una sola cuenta)

- Inserta Access Token en la cabecera de los  requests de actualización de Cache (Nombre del parametro en duro "X-JOKO-AUTH")

- Remueve Endpoint de prueba para obtener el Request Token que guardo el Worker

- Agrega otra configuración al properties para definir el Timer del Worker de Cache de Lectura (Usaba el mismo timer que el de Login hasta el momento)

- Aplica un refactoring del nombre de palabras clave

- Aplica correcciones del Sonar para casi todas las alertas creadas en este ticket, pero estaria entrando una alerta de vulnerabilidad que se quiere resolver en WIL-15 y algunas alertas por haber marcado algo como "TODO"